### PR TITLE
feat(ns-api)!: change owner labels controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ CMD ["/app/entrypoint.sh"]
 # Add metadata labels
 LABEL org.opencontainers.image.version=${GIT_HASH}
 LABEL org.opencontainers.image.created=${BUILD_DATE}
-LABEL org.opencontainers.image.documentation="https://github.com/Ramblurr/crunchy-userinit-controller"
-LABEL org.opencontainers.image.source="https://github.com/Ramblurr/crunchy-userinit-controller"
-LABEL org.opencontainers.image.vendor="@ramblurr"
+LABEL org.opencontainers.image.documentation="https://github.com/DrummyFloyd/crunchy-userinit-controller/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/DrummyFloyd/crunchy-userinit-controller"
+LABEL org.opencontainers.image.vendor="@drummyfloyd"

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ spec:
   metadata:
     labels:
       # This label is required for the userinit-controller to activate
-      crunchy-userinit.ramblurr.github.com/enabled: "true"
+      crunchy-userinit.drummyfloyd.github.com/enabled: "true"
       # This label is required to tell the userinit-controller which user is the the superuser
-      crunchy-userinit.ramblurr.github.com/superuser: "dbroot"
+      crunchy-userinit.drummyfloyd.github.com/superuser: "dbroot"
   postgresVersion: 16
 
   ... snip ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ lint = [
     "ruff>=0.12.5",
 ]
 test = [
+    "kubernetes>=33.1.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.1",
     "pytest-cov>=6.2.1",

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from kubernetes import client, config
 
 # Add src directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -100,17 +101,23 @@ def mock_k8s_secret():
         dbname: str = "testdb",
         superuser: str = "postgres",
         enabled: bool = True,
+        actual_annotations: bool = True,
+        actual_labels: bool = True,
         deprecated_labels: bool = False,
         deprecated_annotations: bool = False,
     ) -> MockSecret:
-        labels = {
-            "postgres-operator.crunchydata.com/cluster": cluster_name,
-            "postgres-operator.crunchydata.com/role": "pguser",
-        }
-        annotations = {
-            "crunchy-userinit.drummyfloyd.github.com/kopf-managed": "yes",
-            "crunchy-userinit.drummyfloyd.github.com/last-handled-configuration": "random-config",
-        }
+        labels = {}
+        annotations = {}
+        if actual_labels:
+            labels = {
+                "postgres-operator.crunchydata.com/cluster": cluster_name,
+                "postgres-operator.crunchydata.com/role": "pguser",
+            }
+        if actual_annotations:
+            annotations = {
+                "crunchy-userinit.drummyfloyd.github.com/kopf-managed": "yes",
+                "crunchy-userinit.drummyfloyd.github.com/last-handled-configuration": "random-config",
+            }
         if deprecated_labels:
             labels["crunchy-userinit.ramblurr.github.com/enabled"] = "true"
             labels["crunchy-userinit.ramblurr.github.com/superuser"] = superuser
@@ -309,3 +316,20 @@ def data_generators():
             return f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
 
     return DataGenerators
+
+
+@pytest.fixture
+def k8s_connection():
+    """Ensure we are connected to the Kubernetes cluster."""
+    try:
+        config.load_kube_config()
+    except config.ConfigException:
+        config.load_incluster_config()
+
+    # Verify connection
+    v1 = client.CoreV1Api()
+    try:
+        v1.list_namespace()
+        print("✓ Kubernetes connection verified")
+    except Exception as e:
+        pytest.fail(f"Failed to connect to Kubernetes: {e}")

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -21,7 +21,7 @@ class MockSecret:
     """
 
     def __init__(self, data_dict):
-        # Store the original dict for get() method
+        # Store the original dict for get() method and iteration
         self._dict = data_dict
         # Convert nested structures to support dot notation
         for key, value in data_dict.items():
@@ -41,7 +41,10 @@ class MockSecret:
     def __setitem__(self, key, value):
         """Allow setting values."""
         self._dict[key] = value
-        setattr(self, key, value)
+        if isinstance(value, dict):
+            setattr(self, key, MockSecret(value))
+        else:
+            setattr(self, key, value)
 
     def __delitem__(self, key):
         """Allow deleting keys."""
@@ -52,6 +55,30 @@ class MockSecret:
     def __contains__(self, key):
         """Support 'in' operator."""
         return key in self._dict
+
+    def __iter__(self):
+        """Support iteration over keys."""
+        return iter(self._dict)
+
+    def __len__(self):
+        """Support len() function."""
+        return len(self._dict)
+
+    def keys(self):
+        """Return dict keys."""
+        return self._dict.keys()
+
+    def values(self):
+        """Return dict values."""
+        return self._dict.values()
+
+    def items(self):
+        """Return dict items."""
+        return self._dict.items()
+
+    def __repr__(self):
+        """String representation for debugging."""
+        return f"MockSecret({self._dict!r})"
 
 
 @pytest.fixture(scope="session")
@@ -73,23 +100,39 @@ def mock_k8s_secret():
         dbname: str = "testdb",
         superuser: str = "postgres",
         enabled: bool = True,
+        deprecated_labels: bool = False,
+        deprecated_annotations: bool = False,
     ) -> MockSecret:
         labels = {
             "postgres-operator.crunchydata.com/cluster": cluster_name,
             "postgres-operator.crunchydata.com/role": "pguser",
         }
+        annotations = {
+            "crunchy-userinit.drummyfloyd.github.com/kopf-managed": "yes",
+            "crunchy-userinit.drummyfloyd.github.com/last-handled-configuration": "random-config",
+        }
+        if deprecated_labels:
+            labels["crunchy-userinit.ramblurr.github.com/enabled"] = "true"
+            labels["crunchy-userinit.ramblurr.github.com/superuser"] = superuser
+
+        if deprecated_annotations:
+            annotations["crunchy-userinit.ramblurr.github.com/kopf-managed"] = "true"
+            annotations[
+                "crunchy-userinit.ramblurr.github.com/last-handled-configuration"
+            ] = "random-config"
 
         if enabled:
-            labels["crunchy-userinit.ramblurr.github.com/enabled"] = "true"
+            labels["crunchy-userinit.drummyfloyd.github.com/enabled"] = "true"
 
         if superuser:
-            labels["crunchy-userinit.ramblurr.github.com/superuser"] = superuser
+            labels["crunchy-userinit.drummyfloyd.github.com/superuser"] = superuser
 
         secret_data = {
             "metadata": {
                 "name": f"{cluster_name}-pguser-{username}",
                 "namespace": namespace,
                 "labels": labels,
+                "annotations": annotations,
             },
             "data": {
                 "dbname": base64.b64encode(dbname.encode()).decode(),
@@ -140,11 +183,15 @@ def valid_secret_body():
             "metadata": {
                 "name": "test-cluster-pguser-testuser",
                 "namespace": "test-ns",
+                "annotations": {
+                    "crunchy-userinit.drummyfloyd.github.com/kopf-managed": "yes",
+                    "crunchy-userinit.drummyfloyd.github.com/last-handled-configuration": "random-config",
+                },
                 "labels": {
                     "postgres-operator.crunchydata.com/cluster": "test-cluster",
                     "postgres-operator.crunchydata.com/role": "pguser",
-                    "crunchy-userinit.ramblurr.github.com/enabled": "true",
-                    "crunchy-userinit.ramblurr.github.com/superuser": "postgres",
+                    "crunchy-userinit.drummyfloyd.github.com/enabled": "true",
+                    "crunchy-userinit.drummyfloyd.github.com/superuser": "postgres",
                 },
             },
             "data": {

--- a/src/tests/integration/integration_cluster1.py
+++ b/src/tests/integration/integration_cluster1.py
@@ -15,7 +15,7 @@ os.environ["DEV_MODE"] = "true"  # Set DEV_MODE environment variable for testing
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 SECRET_NAME_USER1 = f"{YAML_FILE}-pguser-user1"
-PATCH_DECPRECATED_ANNOTATIONS = {
+PATCH_DEPRECATED_ANNOTATIONS = {
     "metadata": {
         "annotations": {
             "crunchy-userinit.ramblurr.github.com/kopf": "yes",
@@ -79,7 +79,7 @@ class IntegrationWithCluster1:
         _ = v1.patch_namespaced_secret(
             name=SECRET_NAME_USER1,
             namespace=YAML_FILE,
-            body=PATCH_DECPRECATED_ANNOTATIONS,
+            body=PATCH_DEPRECATED_ANNOTATIONS,
         )
         with KopfRunner(
             [

--- a/src/tests/integration/integration_cluster1.py
+++ b/src/tests/integration/integration_cluster1.py
@@ -7,18 +7,28 @@ from pathlib import Path
 
 import kopf
 import pytest
+from kubernetes import client
 
 YAML_FILE = "cluster1"
 
 os.environ["DEV_MODE"] = "true"  # Set DEV_MODE environment variable for testing]
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+SECRET_NAME_USER1 = f"{YAML_FILE}-pguser-user1"
+PATCH_DECPRECATED_ANNOTATIONS = {
+    "metadata": {
+        "annotations": {
+            "crunchy-userinit.ramblurr.github.com/kopf": "yes",
+            "crunchy-userinit.ramblurr.github.com/last-handled-configuration": "random config",
+        }
+    }
+}
+
 
 @pytest.mark.integration
 @pytest.mark.requires_k8s
+@pytest.mark.usefixtures("k8s_connection")
 class IntegrationWithCluster1:
-    """Test the controller's behavior with a real Kubernetes cluster."""
-
     def test_on_startup(self):
         from kopf.testing import KopfRunner
 
@@ -28,10 +38,8 @@ class IntegrationWithCluster1:
         with KopfRunner(
             [
                 "run",
-                # "--standalone",
                 "-n",
                 YAML_FILE,
-                # "--verbose",
                 "-m",
                 "userinit.userinit",
             ],
@@ -66,8 +74,13 @@ class IntegrationWithCluster1:
         from kopf.testing import KopfRunner
 
         settings = kopf.OperatorSettings()
-        # settings.watching.server_timeout = 10
+        v1 = client.CoreV1Api()
 
+        _ = v1.patch_namespaced_secret(
+            name=SECRET_NAME_USER1,
+            namespace=YAML_FILE,
+            body=PATCH_DECPRECATED_ANNOTATIONS,
+        )
         with KopfRunner(
             [
                 "run",
@@ -79,20 +92,27 @@ class IntegrationWithCluster1:
             settings=settings,
         ) as runner:
             time.sleep(5)
-            _ = subprocess.run(
-                f"src/tests/integration/deploy.sh --pg-delete {YAML_FILE}",
-                shell=True,
-                check=True,
-                timeout=10,
-                capture_output=True,
-            )
-            time.sleep(1)
 
         output = runner.output
-        print(output)
 
+        print(output)
+        current_secret = v1.read_namespaced_secret(
+            name=SECRET_NAME_USER1, namespace=YAML_FILE
+        )
+
+        _ = subprocess.run(
+            f"src/tests/integration/deploy.sh --pg-delete {YAML_FILE}",
+            shell=True,
+            check=True,
+            timeout=10,
+            capture_output=True,
+        )
         assert runner.exception is None
         assert runner.exit_code == 0
         assert "running in dev mode" in output
         assert "current owner of user2_main is user2. nothing to do." in output
         assert "current owner of user1_main is user1. nothing to do." in output
+        assert not any(
+            "crunchy-userinit.ramblurr.github.com" in key
+            for key in current_secret.metadata.annotations
+        )

--- a/src/tests/integration/manifests/cluster1.yaml
+++ b/src/tests/integration/manifests/cluster1.yaml
@@ -15,8 +15,8 @@ spec:
   postgresVersion: 17
   metadata:
     labels:
-      crunchy-userinit.ramblurr.github.com/enabled: "true"
-      crunchy-userinit.ramblurr.github.com/superuser: postgres
+      crunchy-userinit.drummyfloyd.github.com/enabled: "true"
+      crunchy-userinit.drummyfloyd.github.com/superuser: postgres
   patroni: {}
   service:
     type: NodePort

--- a/src/tests/integration/manifests/default-pg.yaml
+++ b/src/tests/integration/manifests/default-pg.yaml
@@ -17,7 +17,6 @@ spec:
     labels:
       crunchy-userinit.drummyfloyd.github.com/enabled: "true"
       crunchy-userinit.drummyfloyd.github.com/superuser: postgres
-      random: "true"
   patroni: {}
   service:
     type: NodePort

--- a/src/tests/integration/manifests/default-pg.yaml
+++ b/src/tests/integration/manifests/default-pg.yaml
@@ -15,8 +15,9 @@ spec:
   postgresVersion: 17
   metadata:
     labels:
-      crunchy-userinit.ramblurr.github.com/enabled: "true"
-      crunchy-userinit.ramblurr.github.com/superuser: postgres
+      crunchy-userinit.drummyfloyd.github.com/enabled: "true"
+      crunchy-userinit.drummyfloyd.github.com/superuser: postgres
+      random: "true"
   patroni: {}
   service:
     type: NodePort

--- a/src/tests/unittest/test_models.py
+++ b/src/tests/unittest/test_models.py
@@ -58,7 +58,7 @@ class TestPgUserSecret:
     def test_from_k8s_secret_missing_superuser_label(self, valid_secret_body):
         # Test when superuser label is missing
         del valid_secret_body.metadata.labels[
-            "crunchy-userinit.ramblurr.github.com/superuser"
+            "crunchy-userinit.drummyfloyd.github.com/superuser"
         ]
 
         with pytest.raises(kopf.TemporaryError, match="superuser label not found"):

--- a/src/tests/unittest/test_userinit.py
+++ b/src/tests/unittest/test_userinit.py
@@ -30,7 +30,7 @@ class TestPgUserSecretHandler:
         mock_db_manager = AsyncMock()
         mock_db_manager_class.return_value = mock_db_manager
 
-        await on_pguser_secret_created(body=valid_secret_body)
+        await on_pguser_secret_created(body=valid_secret_body, patch=valid_secret_body)
 
         mock_open_conn.assert_called_once_with("test-ns", "test-cluster", "postgres")
         mock_db_manager_class.assert_called_once_with(mock_conn)
@@ -43,11 +43,13 @@ class TestPgUserSecretHandler:
     ):
         # Test when superuser label is missing
         del valid_secret_body.metadata.labels[
-            "crunchy-userinit.ramblurr.github.com/superuser"
+            "crunchy-userinit.drummyfloyd.github.com/superuser"
         ]
 
         with pytest.raises(kopf.TemporaryError, match="superuser label not found"):
-            await on_pguser_secret_created(body=valid_secret_body)
+            await on_pguser_secret_created(
+                body=valid_secret_body, patch=valid_secret_body
+            )
 
     @pytest.mark.asyncio
     async def test_on_pguser_secret_created_missing_dbname(self, valid_secret_body):
@@ -55,7 +57,9 @@ class TestPgUserSecretHandler:
         del valid_secret_body.data["dbname"]
 
         with pytest.raises(kopf.TemporaryError, match="Could not parse dbname"):
-            await on_pguser_secret_created(body=valid_secret_body)
+            await on_pguser_secret_created(
+                body=valid_secret_body, patch=valid_secret_body
+            )
 
     @pytest.mark.asyncio
     async def test_on_pguser_secret_created_missing_user(self, valid_secret_body):
@@ -63,7 +67,9 @@ class TestPgUserSecretHandler:
         del valid_secret_body.data["user"]
 
         with pytest.raises(kopf.TemporaryError, match="Could not parse role_name"):
-            await on_pguser_secret_created(body=valid_secret_body)
+            await on_pguser_secret_created(
+                body=valid_secret_body, patch=valid_secret_body
+            )
 
     @pytest.mark.asyncio
     async def test_on_pguser_secret_created_superuser_skip(self, valid_secret_body):
@@ -72,7 +78,9 @@ class TestPgUserSecretHandler:
 
         # Should return without error and without calling change_owner
         with patch("userinit.userinit.DatabaseManager") as mock_db_manager_class:
-            await on_pguser_secret_created(body=valid_secret_body)
+            await on_pguser_secret_created(
+                body=valid_secret_body, patch=valid_secret_body
+            )
             mock_db_manager_class.assert_not_called()
 
     @pytest.mark.asyncio
@@ -90,7 +98,9 @@ class TestPgUserSecretHandler:
         mock_db_manager_class.return_value = mock_db_manager
 
         with pytest.raises(kopf.TemporaryError, match="Failed to change the owner"):
-            await on_pguser_secret_created(body=valid_secret_body)
+            await on_pguser_secret_created(
+                body=valid_secret_body, patch=valid_secret_body
+            )
 
         # Ensure connection is still closed even on error
         mock_conn.close.assert_called_once()
@@ -104,4 +114,6 @@ class TestPgUserSecretHandler:
         mock_open_conn.side_effect = kopf.TemporaryError("Connection failed", delay=10)
 
         with pytest.raises(kopf.TemporaryError, match="Connection failed"):
-            await on_pguser_secret_created(body=valid_secret_body)
+            await on_pguser_secret_created(
+                body=valid_secret_body, patch=valid_secret_body
+            )

--- a/src/tests/unittest/test_userinit.py
+++ b/src/tests/unittest/test_userinit.py
@@ -10,7 +10,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # Import the main userinit handler
-from userinit.userinit import on_pguser_secret_created
+from userinit.userinit import on_deprecated_labels, on_pguser_secret_created
 
 
 @pytest.mark.unit
@@ -117,3 +117,16 @@ class TestPgUserSecretHandler:
             await on_pguser_secret_created(
                 body=valid_secret_body, patch=valid_secret_body
             )
+
+
+@pytest.mark.unit
+class TestDeprecatedLabels:
+    """Test handling of deprecated labels."""
+
+    async def test_deprecated_labels_error(self, mock_k8s_secret):
+        deprecated_secret_body = mock_k8s_secret(
+            actual_annotations=False, actual_labels=False, deprecated_labels=True
+        )
+
+        with pytest.raises(kopf.PermanentError):
+            await on_deprecated_labels(body=deprecated_secret_body)

--- a/src/userinit/config.py
+++ b/src/userinit/config.py
@@ -6,12 +6,19 @@ import os
 #############
 
 APP_NAME = "crunchy-userinit"
-K8S_API_NS = "crunchy-userinit.ramblurr.github.com"
+K8S_API_NS = "crunchy-userinit.drummyfloyd.github.com"
+K8S_API_NS_DEPRECATED = "crunchy-userinit.ramblurr.github.com"
 LABEL_ENABLED = f"{K8S_API_NS}/enabled"
+LABEL_ENABLED_DEPREACTED = f"{K8S_API_NS_DEPRECATED}/enabled"
 LABEL_SUPERUSER = f"{K8S_API_NS}/superuser"
+ANNOTATION_MIGRATED = f"{K8S_API_NS}/migrated"
 LABELS_MATCH = {
     "postgres-operator.crunchydata.com/role": "pguser",
     LABEL_ENABLED: "true",
+}
+LABELS_MATCH_DEPRECATED = {
+    "postgres-operator.crunchydata.com/role": "pguser",
+    LABEL_ENABLED_DEPREACTED: "true",
 }
 CRUI_WATCH_NAMESPACE = os.environ.get("CRUI_WATCH_NAMESPACE", "default")
 

--- a/src/userinit/config.py
+++ b/src/userinit/config.py
@@ -9,7 +9,7 @@ APP_NAME = "crunchy-userinit"
 K8S_API_NS = "crunchy-userinit.drummyfloyd.github.com"
 K8S_API_NS_DEPRECATED = "crunchy-userinit.ramblurr.github.com"
 LABEL_ENABLED = f"{K8S_API_NS}/enabled"
-LABEL_ENABLED_DEPREACTED = f"{K8S_API_NS_DEPRECATED}/enabled"
+LABEL_ENABLED_DEPRECATED = f"{K8S_API_NS_DEPRECATED}/enabled"
 LABEL_SUPERUSER = f"{K8S_API_NS}/superuser"
 ANNOTATION_MIGRATED = f"{K8S_API_NS}/migrated"
 LABELS_MATCH = {
@@ -18,7 +18,7 @@ LABELS_MATCH = {
 }
 LABELS_MATCH_DEPRECATED = {
     "postgres-operator.crunchydata.com/role": "pguser",
-    LABEL_ENABLED_DEPREACTED: "true",
+    LABEL_ENABLED_DEPRECATED: "true",
 }
 CRUI_WATCH_NAMESPACE = os.environ.get("CRUI_WATCH_NAMESPACE", "default")
 

--- a/src/userinit/userinit.py
+++ b/src/userinit/userinit.py
@@ -2,12 +2,10 @@ import kopf
 from kubernetes_asyncio import config
 
 from .config import (
-    ANNOTATION_MIGRATED,
     DEV_MODE,
     K8S_API_NS,
     K8S_API_NS_DEPRECATED,
     LABELS_MATCH,
-    LABELS_MATCH_DEPRECATED,
     logger,
 )
 from .connections import ConnectionManager
@@ -17,6 +15,7 @@ from .models import PgUserSecret
 
 @kopf.on.startup(id="crui-startup")
 async def configure(settings: kopf.OperatorSettings, **_):
+    # INFO: Lines 20-27: tested with pytest.marker.integration
     settings.peering.standalone = True
     settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStorage(
         prefix=K8S_API_NS, key="last-handled-configuration", v1=False
@@ -24,31 +23,8 @@ async def configure(settings: kopf.OperatorSettings, **_):
     if DEV_MODE:
         logger.warning("running in dev mode")
         _ = await config.load_kube_config()
-    else:
+    else:  # pragma: no cover
         config.load_incluster_config()
-
-
-@kopf.on.update(
-    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="update-crui-deprecated"
-)
-@kopf.on.create(
-    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="create-crui-deprecated"
-)
-@kopf.on.resume(
-    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="resume-crui-deprecated"
-)
-async def on_deprecated_labels(body: kopf.Body, patch: kopf.Patch, **_):
-    """Handle deprecated label events"""
-    for annotation in body.metadata.annotations:
-        if annotation.startswith(K8S_API_NS_DEPRECATED):
-            logger.warning(
-                f"removing deprecated annotation {annotation} from secret {body.metadata.name}"
-            )
-            patch.metadata.annotations[annotation] = None
-    patch.metadata.annotations[ANNOTATION_MIGRATED] = "False"
-    raise kopf.PermanentError(
-        f"deprecated labels detected on secret {body.metadata.name}, please update to use {K8S_API_NS} instead of {K8S_API_NS_DEPRECATED}"
-    )
 
 
 @kopf.on.create("", "v1", "secret", labels=LABELS_MATCH, id="create-crui")
@@ -57,13 +33,14 @@ async def on_deprecated_labels(body: kopf.Body, patch: kopf.Patch, **_):
 async def on_pguser_secret_created(body: kopf.Body, patch: kopf.Patch, **_):
     """Handle PostgreSQL user secret creation/update events"""
 
-    if any(K8S_API_NS_DEPRECATED in key for key in body.metadata.labels):
-        logger.warning(
-            f"Secret '{body.metadata.name}' contains unused deprecated label '{K8S_API_NS_DEPRECATED}'.Consider removing it for clarity since the current labels are already in use."
-        )
-        patch.metadata.annotations[ANNOTATION_MIGRATED] = "True"
-    else:
-        patch.metadata.annotations[ANNOTATION_MIGRATED] = None
+    # INFO: block if: tested with pytest.marker.integration
+    for annotation in body.metadata.annotations:
+        if annotation.startswith(K8S_API_NS_DEPRECATED):
+            logger.warning(
+                f"removing deprecated annotation {annotation} from secret {body.metadata.name}"
+            )
+            patch.metadata.annotations[annotation] = None
+
     try:
         # Parse and validate the secret
         pguser_secret = PgUserSecret.from_k8s_secret(body)
@@ -98,7 +75,7 @@ async def on_pguser_secret_created(body: kopf.Body, patch: kopf.Patch, **_):
     except kopf.TemporaryError:
         # Re-raise kopf errors as-is
         raise
-    except Exception as e:
+    except Exception as e:  # pragma: no cover no need to test this
         # Wrap unexpected errors
         raise kopf.TemporaryError(
             f"Unexpected error processing pguser secret: {e}",

--- a/src/userinit/userinit.py
+++ b/src/userinit/userinit.py
@@ -1,17 +1,25 @@
 import kopf
 from kubernetes_asyncio import config
 
-from .config import DEV_MODE, K8S_API_NS, LABELS_MATCH, logger
+from .config import (
+    ANNOTATION_MIGRATED,
+    DEV_MODE,
+    K8S_API_NS,
+    K8S_API_NS_DEPRECATED,
+    LABELS_MATCH,
+    LABELS_MATCH_DEPRECATED,
+    logger,
+)
 from .connections import ConnectionManager
 from .database import DatabaseManager
 from .models import PgUserSecret
 
 
-@kopf.on.startup()
+@kopf.on.startup(id="crui-startup")
 async def configure(settings: kopf.OperatorSettings, **_):
+    settings.peering.standalone = True
     settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStorage(
-        prefix=K8S_API_NS,
-        key="last-handled-configuration",
+        prefix=K8S_API_NS, key="last-handled-configuration", v1=False
     )
     if DEV_MODE:
         logger.warning("running in dev mode")
@@ -21,25 +29,41 @@ async def configure(settings: kopf.OperatorSettings, **_):
 
 
 @kopf.on.update(
-    "",
-    "v1",
-    "secret",
-    labels=LABELS_MATCH,
+    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="update-crui-deprecated"
 )
 @kopf.on.create(
-    "",
-    "v1",
-    "secret",
-    labels=LABELS_MATCH,
+    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="create-crui-deprecated"
 )
 @kopf.on.resume(
-    "",
-    "v1",
-    "secret",
-    labels=LABELS_MATCH,
+    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="resume-crui-deprecated"
 )
-async def on_pguser_secret_created(body: kopf.Body, **_):
+async def on_deprecated_labels(body: kopf.Body, patch: kopf.Patch, **_):
+    """Handle deprecated label events"""
+    for annotation in body.metadata.annotations:
+        if annotation.startswith(K8S_API_NS_DEPRECATED):
+            logger.warning(
+                f"removing deprecated annotation {annotation} from secret {body.metadata.name}"
+            )
+            patch.metadata.annotations[annotation] = None
+    patch.metadata.annotations[ANNOTATION_MIGRATED] = "False"
+    raise kopf.PermanentError(
+        f"deprecated labels detected on secret {body.metadata.name}, please update to use {K8S_API_NS} instead of {K8S_API_NS_DEPRECATED}"
+    )
+
+
+@kopf.on.create("", "v1", "secret", labels=LABELS_MATCH, id="create-crui")
+@kopf.on.update("", "v1", "secret", labels=LABELS_MATCH, id="update-crui")
+@kopf.on.resume("", "v1", "secret", labels=LABELS_MATCH, id="resume-crui")
+async def on_pguser_secret_created(body: kopf.Body, patch: kopf.Patch, **_):
     """Handle PostgreSQL user secret creation/update events"""
+
+    if any(K8S_API_NS_DEPRECATED in key for key in body.metadata.labels):
+        logger.warning(
+            f"Secret '{body.metadata.name}' contains unused deprecated label '{K8S_API_NS_DEPRECATED}'.Consider removing it for clarity since the current labels are already in use."
+        )
+        patch.metadata.annotations[ANNOTATION_MIGRATED] = "True"
+    else:
+        patch.metadata.annotations[ANNOTATION_MIGRATED] = None
     try:
         # Parse and validate the secret
         pguser_secret = PgUserSecret.from_k8s_secret(body)
@@ -69,7 +93,7 @@ async def on_pguser_secret_created(body: kopf.Body, **_):
                 delay=60,
             )
         finally:
-            await conn.close()
+            _ = await conn.close()
 
     except kopf.TemporaryError:
         # Re-raise kopf errors as-is

--- a/src/userinit/userinit.py
+++ b/src/userinit/userinit.py
@@ -6,6 +6,7 @@ from .config import (
     K8S_API_NS,
     K8S_API_NS_DEPRECATED,
     LABELS_MATCH,
+    LABELS_MATCH_DEPRECATED,
     logger,
 )
 from .connections import ConnectionManager
@@ -24,7 +25,7 @@ async def configure(settings: kopf.OperatorSettings, **_):
         logger.warning("running in dev mode")
         _ = await config.load_kube_config()
     else:  # pragma: no cover
-        config.load_incluster_config()
+        _ = config.load_incluster_config()
 
 
 @kopf.on.create("", "v1", "secret", labels=LABELS_MATCH, id="create-crui")
@@ -81,3 +82,19 @@ async def on_pguser_secret_created(body: kopf.Body, patch: kopf.Patch, **_):
             f"Unexpected error processing pguser secret: {e}",
             delay=60,
         )
+
+
+@kopf.on.create(
+    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="create-deprecated"
+)
+@kopf.on.update(
+    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="update-deprecated"
+)
+@kopf.on.resume(
+    "", "v1", "secret", labels=LABELS_MATCH_DEPRECATED, id="resume-deprecated"
+)
+async def on_deprecated_labels(body: kopf.Body, **_):
+    """Handle deprecated label events"""
+    raise kopf.PermanentError(
+        f"deprecated labels detected on secret {body.metadata.name}, please update to use {K8S_API_NS} instead of {K8S_API_NS_DEPRECATED}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -101,12 +101,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.7.14"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995", size = 163981, upload-time = "2025-07-14T03:29:28.449Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2", size = 162722, upload-time = "2025-07-14T03:29:26.863Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936, upload-time = "2025-05-02T08:32:33.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790, upload-time = "2025-05-02T08:32:35.768Z" },
+    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924, upload-time = "2025-05-02T08:32:37.284Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626, upload-time = "2025-05-02T08:32:38.803Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567, upload-time = "2025-05-02T08:32:40.251Z" },
+    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957, upload-time = "2025-05-02T08:32:41.705Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408, upload-time = "2025-05-02T08:32:43.709Z" },
+    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399, upload-time = "2025-05-02T08:32:46.197Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815, upload-time = "2025-05-02T08:32:48.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537, upload-time = "2025-05-02T08:32:49.719Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565, upload-time = "2025-05-02T08:32:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357, upload-time = "2025-05-02T08:32:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776, upload-time = "2025-05-02T08:32:54.573Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622, upload-time = "2025-05-02T08:32:56.363Z" },
+    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435, upload-time = "2025-05-02T08:32:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653, upload-time = "2025-05-02T08:33:00.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231, upload-time = "2025-05-02T08:33:02.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243, upload-time = "2025-05-02T08:33:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442, upload-time = "2025-05-02T08:33:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147, upload-time = "2025-05-02T08:33:08.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057, upload-time = "2025-05-02T08:33:09.986Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454, upload-time = "2025-05-02T08:33:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174, upload-time = "2025-05-02T08:33:13.707Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload-time = "2025-05-02T08:33:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload-time = "2025-05-02T08:33:17.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload-time = "2025-05-02T08:33:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
 ]
 
 [[package]]
@@ -184,6 +228,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "kubernetes" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -193,6 +238,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
+    { name = "kubernetes" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -207,6 +253,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -214,9 +261,19 @@ dev = [
 ]
 lint = [{ name = "ruff", specifier = ">=0.12.5" }]
 test = [
+    { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -280,6 +337,20 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.40.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -321,6 +392,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/f1/6b132164de2cae56761ea84f7947f0f5fdcd0db2168adec811052131947d/kopf-1.37.1.tar.gz", hash = "sha256:f38829cb702d788ab536ecd51f10d83175b971874af1d6c8178a864cf9af4ece", size = 1190955, upload-time = "2024-01-20T17:31:44.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/2e/01e2faa18961ba23c4b8a48006b0c1897c25755e0425cbf0795945b757c5/kopf-1.37.1-py3-none-any.whl", hash = "sha256:dbeafe715987705d6fb44a49a26ca065b9e537a85c654efa94a520c6d16509d5", size = 207452, upload-time = "2024-01-20T17:31:39.299Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "33.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "google-auth" },
+    { name = "oauthlib" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/52/19ebe8004c243fdfa78268a96727c71e08f00ff6fe69a301d0b7fcbce3c2/kubernetes-33.1.0.tar.gz", hash = "sha256:f64d829843a54c251061a8e7a14523b521f2dc5c896cf6d65ccf348648a88993", size = 1036779, upload-time = "2025-06-09T21:57:58.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/43/d9bebfc3db7dea6ec80df5cb2aad8d274dd18ec2edd6c4f21f32c237cbbb/kubernetes-33.1.0-py2.py3-none-any.whl", hash = "sha256:544de42b24b64287f7e0aa9513c93cb503f7f40eea39b20f66810011a86eabc5", size = 1941335, upload-time = "2025-06-09T21:57:56.327Z" },
 ]
 
 [[package]]
@@ -405,6 +498,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -477,6 +579,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175, upload-time = "2025-06-09T22:55:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857, upload-time = "2025-06-09T22:55:39.687Z" },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -578,6 +701,46 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +799,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## **BREAKING CHANGE: Organization Migration**

**Owner Transfer:** Moving labels from `ramblurr` organization to `drummyfloyd` organization

**API Deprecation:** The old `K8S_API_NS` is being deprecated and migrated from `crunchy-userinit.ramblurr.github.com` to `crunchy-userinit.drummyfloyd.github.com`

### **Changes:**

- **Controllers will reject legacy labels:** Secrets with old labels will receive a `PermanentError`:
  ```yaml
  # ❌ DEPRECATED - Will cause PermanentError
  labels:
    "crunchy-userinit.ramblurr.github.com/enabled": "true"
    "crunchy-userinit.ramblurr.github.com/superuser": "postgres"
  ```

- **New label namespace required:** Update your PostgresCluster manifests to use:
  ```yaml
  # ✅ REQUIRED - New label namespace
  labels:
    "crunchy-userinit.drummyfloyd.github.com/enabled": "true"
    "crunchy-userinit.drummyfloyd.github.com/superuser": "postgres"
  ```

- **Automatic cleanup:** The controller will automatically remove deprecated annotations from secrets

### **Migration Required:**

**⚠️ MANUAL ACTION NEEDED:** This is **not** an automatic migration. You must:

1. **Update your PostgresCluster manifests** to use the new label namespace
2. **Redeploy your PostgresCluster resources** with updated labels
3. **Existing databases retain their ownership** - no data loss 

### **Migration Steps:**

```bash
# 1. Update your PostgresCluster YAML files
sed -i 's/crunchy-userinit\.ramblurr\.github\.com/crunchy-userinit.drummyfloyd.github.com/g' your-postgres-cluster.yaml

# 2. Apply the updated manifest
kubectl apply -f your-postgres-cluster.yaml
```

### **Impact:**

- **✅ No data loss:** Existing database ownership remains intact
- **⚠️ service disruption:** Operator will redeploy with new labels
- **⚠️ Controller functionality:** New user secrets will fail to process until manifests are updated
- **📋 One-time change:** Once migrated, no further action required

### **Timeline:**

- **Immediate:** Secrets with old labels will receive errors
- **Action required:** Update your PostgresCluster manifests before creating new users
- **Existing users:** Continue working without interruption

# TODO

- [x] add deprecation warning & cleanup actions
- [x] update docs
- [x] update tests

Related: #10 