### PR TITLE
feat(chart)!: global rework controller configuration

### DIFF
--- a/charts/crunchy-userinit/Chart.yaml
+++ b/charts/crunchy-userinit/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 version: 0.0.5
 appVersion: "0.0.5"
 maintainers:
-  - name: ramblurr
-    email: unnamedrambler@gmail.com
+  - name: drummyfloyd
+    email: false.drummyfloyd@gmail.com

--- a/charts/crunchy-userinit/README.gotmpl
+++ b/charts/crunchy-userinit/README.gotmpl
@@ -1,0 +1,24 @@
+
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "chart.valuesSectionHtml" . }}

--- a/charts/crunchy-userinit/README.md
+++ b/charts/crunchy-userinit/README.md
@@ -8,9 +8,20 @@ Installs crunchy-userinit-controller
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| ramblurr | <unnamedrambler@gmail.com> |  |
+| drummyfloyd | <false.drummyfloyd@gmail.com> |  |
 
 ## Values
+
+### Controller configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| rbac.create | bool | `true` | Create RBAC resources |
+| rbac.forceCluster | bool | `false` | Force cluster-level RBAC regardless of watch configuration When false (default), cluster RBAC is automatically enabled if: - watch.mode is "all" - watch.namespaces contains regex patterns (* ? [ ]) When true, always use cluster RBAC |
+| watch.mode | string | `"current"` | Watch mode: "current" | "all" | "list" current: Watch only the namespace where controller is deployed all: Watch all namespaces (automatically enables cluster RBAC) list: Watch specific namespaces listed in 'namespaces' |
+| watch.namespaces | list | `[]` | List of namespaces to watch (only used when mode="list") Supports Kopf patterns: * (glob), ? (single char), ! (negation), , (multiple) Patterns automatically enable cluster RBAC |
+
+### Other Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -21,12 +32,14 @@ Installs crunchy-userinit-controller
 | image.repository | string | `"ghcr.io/drummyfloyd/crunchy-userinit-controller"` | Container image repository |
 | image.tag | string | `""` | Container image tag (immutable tags are recommended) |
 | imagePullSecrets | list | `[]` | Specify docker-registry secret names as an array |
+| livenessProbe.enabled | bool | `true` | Enabled livenessProbe |
+| log.debug | bool | `false` | Enable debug mode |
+| log.format | string | `"plain"` | Log format of the controller (plain|full|json) |
 | nameOverride | string | `""` | String to partially override crunchy-userinit-controller.fullname template |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations to add to the pod |
 | podLabels | object | `{}` | Labels to add to the pod |
 | podSecurityContext | object | `{}` | Configure pod security context |
-| rbac.create | bool | `true` | Enabled RBAC on namespace level |
 | replicaCount | int | `1` | Set number of replicas |
 | resources | object | `{}` | Resource limits and requests for the controller pod |
 | securityContext | object | `{}` | Configure container security context |

--- a/charts/crunchy-userinit/templates/NOTES.txt
+++ b/charts/crunchy-userinit/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{ include "crunchy-userinit.configSummary" . }}

--- a/charts/crunchy-userinit/templates/_helpers.tpl
+++ b/charts/crunchy-userinit/templates/_helpers.tpl
@@ -60,3 +60,100 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate if a namespace name contains Kopf patterns that require cluster RBAC
+Kopf supports: *, ?, ! (negation), , (multiple patterns)
+*/}}
+{{- define "crunchy-userinit.isKopfPattern" -}}
+{{- $name := . -}}
+{{- $isPattern := false -}}
+{{- if or (contains "*" $name) (contains "?" $name) (contains "!" $name) (contains "," $name) -}}
+  {{- $isPattern = true -}}
+{{- end -}}
+{{- $isPattern -}}
+{{- end -}}
+
+{{- define "crunchy-userinit.needsClusterRBAC" -}}
+{{- $needsCluster := false -}}
+{{- if eq .Values.watch.mode "all" -}}
+  {{- $needsCluster = true -}}
+{{- else if eq .Values.watch.mode "list" -}}
+  {{- range .Values.watch.namespaces -}}
+    {{- $isPattern := include "crunchy-userinit.isKopfPattern" . -}}
+    {{- if eq $isPattern "true" -}}
+      {{- $needsCluster = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.rbac.forceCluster -}}
+  {{- $needsCluster = true -}}
+{{- end -}}
+{{- if $needsCluster -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate watch configuration
+*/}}
+{{- define "crunchy-userinit.validateWatchConfig" -}}
+{{- if not (has .Values.watch.mode (list "current" "all" "list")) -}}
+  {{- fail "watch.mode must be one of: current, all, list" -}}
+{{- end -}}
+
+{{- if and (eq .Values.watch.mode "list") (not .Values.watch.namespaces) -}}
+  {{- fail "watch.namespaces cannot be empty when watch.mode is 'list'" -}}
+{{- end -}}
+
+{{- if and (ne .Values.watch.mode "list") .Values.watch.namespaces -}}
+  {{- fail "watch.namespaces should only be set when watch.mode is 'list'" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate deployment args
+*/}}
+{{- define "crunchy-userinit.deploymentArgs" -}}
+- --log-format={{ .Values.log.format }}
+{{- if .Values.log.debug }}
+- --debug
+{{- end }}
+{{- if .Values.livenessProbe.enabled }}
+- --liveness=http://0.0.0.0:8080/healthz
+{{- end }}
+{{- if eq .Values.watch.mode "all" }}
+- --all-namespaces
+{{- else if eq .Values.watch.mode "list" }}
+{{- range .Values.watch.namespaces }}
+- --namespace={{ . }}
+{{- end }}
+{{- else }}
+- --namespace={{ .Release.Namespace }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Generate configuration summary for NOTES.txt
+*/}}
+{{- define "crunchy-userinit.configSummary" -}}
+{{- $clusterRBAC := include "crunchy-userinit.needsClusterRBAC" . -}}
+
+Configuration Summary:
+- Watch Mode: {{ .Values.watch.mode }}
+{{- if eq .Values.watch.mode "list" }}
+- Watched Namespaces: {{ .Values.watch.namespaces | join ", " }}
+{{- end }}
+- RBAC Type: {{ if eq $clusterRBAC "true" }}Cluster-wide{{ else }}Namespace-scoped{{ end }}
+{{- if .Values.rbac.forceCluster }}
+- Cluster RBAC: Forced enabled
+{{- else if eq $clusterRBAC "true" }}
+{{- if eq .Values.watch.mode "all" }}
+- Cluster RBAC: Auto-enabled (watching all namespaces)
+{{- else }}
+- Cluster RBAC: Auto-enabled (Kopf patterns detected)
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/crunchy-userinit/templates/cluster-role.yaml
+++ b/charts/crunchy-userinit/templates/cluster-role.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.rbac.create (eq (include "crunchy-userinit.needsClusterRBAC" .) "true") -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ include "crunchy-userinit.fullname" . }}-clusterrole"
+  labels:
+    {{- include "crunchy-userinit.labels" . | nindent 4 }}
+rules:
+  # Framework: posting events about handler progress/errors
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create]
+  # Needed to read secrets across namespaces
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ include "crunchy-userinit.fullname" . }}-clusterrolebinding"
+  labels:
+    {{- include "crunchy-userinit.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ include "crunchy-userinit.fullname" . }}-clusterrole"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ include "crunchy-userinit.serviceAccountName" . }}"
+    namespace: "{{ .Release.Namespace }}"
+{{- end -}}

--- a/charts/crunchy-userinit/templates/deployment.yaml
+++ b/charts/crunchy-userinit/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "crunchy-userinit.validateWatchConfig" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,14 +37,16 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- include "crunchy-userinit.deploymentArgs" . | nindent 12 }}
+          {{- if .Values.livenessProbe}}
           livenessProbe:
             httpGet:
               path: /healthz
               port: 8080
-          env:
-            - name: CRUI_WATCH_NAMESPACE
-              value: "{{ .Release.Namespace }}"
+          {{- end }}
             {{- with .Values.extraEnv }}
+          env:
               {{- . | toYaml | nindent 12 }}
             {{- end }}
           resources:

--- a/charts/crunchy-userinit/templates/role.yaml
+++ b/charts/crunchy-userinit/templates/role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create (eq (include "crunchy-userinit.needsClusterRBAC" .) "false") -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: "{{ include "crunchy-userinit.fullname" . }}-role-namespaced"
+  name: "{{ include "crunchy-userinit.fullname" . }}-role"
   namespace: "{{ .Release.Namespace }}"
 rules:
   # Framework: posting events about handler progress/errors (optional but useful for debugging)
@@ -26,4 +26,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: "{{include "crunchy-userinit.serviceAccountName" .}}"
+    namespace: "{{ .Release.Namespace }}"
 {{- end -}}

--- a/charts/crunchy-userinit/tests/__snapshot__/cluster-role_test.yaml.snap
+++ b/charts/crunchy-userinit/tests/__snapshot__/cluster-role_test.yaml.snap
@@ -1,0 +1,56 @@
+should create clusterRole with watch.mode=all:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: crunchy-userinit-controller
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: crunchy-userinit-controller-0.0.0
+      name: test-crunchy-userinit-controller-clusterrole
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - get
+          - list
+          - watch
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: crunchy-userinit-controller
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: crunchy-userinit-controller-0.0.0
+      name: test-crunchy-userinit-controller-clusterrolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: test-crunchy-userinit-controller-clusterrole
+    subjects:
+      - kind: ServiceAccount
+        name: test-crunchy-userinit-controller
+        namespace: test-ns

--- a/charts/crunchy-userinit/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/crunchy-userinit/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,9 +28,10 @@ should match snapshot with default values:
             helm.sh/chart: crunchy-userinit-controller-0.0.0
         spec:
           containers:
-            - env:
-                - name: CRUI_WATCH_NAMESPACE
-                  value: test-ns
+            - args:
+                - --log-format=plain
+                - --liveness=http://0.0.0.0:8080/healthz
+                - --namespace=test-ns
               image: ghcr.io/drummyfloyd/crunchy-userinit-controller:0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/crunchy-userinit/tests/__snapshot__/role_test.yaml.snap
+++ b/charts/crunchy-userinit/tests/__snapshot__/role_test.yaml.snap
@@ -1,9 +1,9 @@
-should match snapshot with defautl:
+should match snapshot with default:
   1: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: test-crunchy-userinit-controller-role-namespaced
+      name: test-crunchy-userinit-controller-role
       namespace: test-ns
     rules:
       - apiGroups:
@@ -35,3 +35,4 @@ should match snapshot with defautl:
     subjects:
       - kind: ServiceAccount
         name: test-crunchy-userinit-controller
+        namespace: test-ns

--- a/charts/crunchy-userinit/tests/cluster-role_test.yaml
+++ b/charts/crunchy-userinit/tests/cluster-role_test.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
-suite: RBAC NS
+suite: RBAC Cluster
 templates:
-  - role.yaml
+  - cluster-role.yaml
 release:
   name: test
   namespace: test-ns
@@ -13,9 +13,6 @@ set:
     repository: ghcr.io/drummyfloyd/crunchy-userinit-controller
     tag: 0.0.0
 tests:
-  - it: should match snapshot with default
-    asserts:
-      - matchSnapshot: {}
   - it: should not create rbac
     set:
       rbac:
@@ -26,8 +23,29 @@ tests:
   - it: should not create rbac when forceCluster
     set:
       rbac:
-        create: true
+        create: false
         forceCluster: true
     asserts:
       - hasDocuments:
           count: 0
+  - it: should create clusterRole with watch.mode=all
+    set:
+      watch:
+        mode: all
+    asserts:
+      - matchSnapshot: {}
+  - it: should create cluster role with watch.mode=list
+    set:
+      watch:
+        mode: list
+    asserts:
+      - matchSnapshot: {}
+  - it: should create cluster role on force
+    set:
+      watch:
+        mode: current
+      rbac:
+        forceCluster: true
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/crunchy-userinit/tests/deployment_test.yaml
+++ b/charts/crunchy-userinit/tests/deployment_test.yaml
@@ -45,14 +45,6 @@ tests:
             app.kubernetes.io/name: crunchy-userinit-controller
             app.kubernetes.io/instance: test
 
-  - it: should have CRUI_WATCH_NAMESPACE environment variable
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: CRUI_WATCH_NAMESPACE
-            value: test-ns
-
   - it: should include extra environment variables
     set:
       extraEnv:
@@ -332,3 +324,52 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].name
           value: crunchy-userinit-controller
+
+  - it: should not render livenessProbe
+    set:
+      livenessProbe:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --log-format=plain
+            - --namespace=test-ns
+  - it: should set all namespace
+    set:
+      watch:
+        mode: all
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --log-format=plain
+            - --liveness=http://0.0.0.0:8080/healthz
+            - --all-namespaces
+  - it: should set list namespaces
+    set:
+      watch:
+        mode: list
+        namespaces:
+          - random
+          - pr-*
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --log-format=plain
+            - --liveness=http://0.0.0.0:8080/healthz
+            - --namespace=random
+            - --namespace=pr-*
+  - it: should set debug mode
+    set:
+      log:
+        debug: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --log-format=plain
+            - --debug
+            - --liveness=http://0.0.0.0:8080/healthz
+            - --namespace=test-ns

--- a/charts/crunchy-userinit/tests/fail_test.yaml
+++ b/charts/crunchy-userinit/tests/fail_test.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Fail
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: test-ns
+chart:
+  version: 0.0.0
+  appVersion: 0.0.0
+tests:
+  - it: should fail on non correct watch.mode
+    set:
+      watch:
+        mode: random
+    asserts:
+      - failedTemplate:
+          errorMessage: "watch.mode must be one of: current, all, list"
+
+  - it: should fail on empty watch.namespaces list
+    set:
+      watch:
+        mode: list
+        namespaces: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "watch.namespaces cannot be empty when watch.mode is 'list'"
+
+  - it: should fail on non empty watch.namespaces with wrong mode
+    set:
+      watch:
+        mode: all
+        namespaces:
+          - random
+    asserts:
+      - failedTemplate:
+          errorMessage: "watch.namespaces should only be set when watch.mode is 'list'"

--- a/charts/crunchy-userinit/values.yaml
+++ b/charts/crunchy-userinit/values.yaml
@@ -9,16 +9,46 @@ image:
   # -- Container image tag (immutable tags are recommended)
   tag: ""
 
+watch:
+  # -- Watch mode: "current" | "all" | "list"
+  # current: Watch only the namespace where controller is deployed
+  # all: Watch all namespaces (automatically enables cluster RBAC)
+  # list: Watch specific namespaces listed in 'namespaces'
+  # @section -- Controller configuration
+  mode: current
+
+  # -- List of namespaces to watch (only used when mode="list")
+  # Supports Kopf patterns: * (glob), ? (single char), ! (negation), , (multiple)
+  # Patterns automatically enable cluster RBAC
+  # @section -- Controller configuration
+  namespaces: []
+  # Examples:
+  # - "production"               # Specific namespace
+  # - "staging"                  # Specific namespace
+  # - "*-pr-123-*"               # enables cluster RBAC
+  # - "app-?"                    # enables cluster RBAC
+  # - "!test-*"                  # enables cluster RBAC
+
 rbac:
-  # TODO: to implement
-  # clusterScope: false
-  # -- Enabled RBAC on namespace level
+  # -- Create RBAC resources
+  # @section -- Controller configuration
   create: true
+  # -- Force cluster-level RBAC regardless of watch configuration
+  # When false (default), cluster RBAC is automatically enabled if:
+  # - watch.mode is "all"
+  # - watch.namespaces contains regex patterns (* ? [ ])
+  # When true, always use cluster RBAC
+  # @section -- Controller configuration
+  forceCluster: false
+
+log:
+  # -- Log format of the controller (plain|full|json)
+  format: plain
+  # -- Enable debug mode
+  debug: false
 
 # -- Additional environment variables to apply to the main pod
 extraEnv: []
-#  - name: DEV_MODE_
-#    value: true
 
 # -- Specify docker-registry secret names as an array
 imagePullSecrets: []
@@ -40,6 +70,10 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+livenessProbe:
+  # -- Enabled livenessProbe
+  enabled: true
 
 # -- Annotations to add to the pod
 podAnnotations: {}


### PR DESCRIPTION
BREAKING CHANGE: Global rework on controller configuration

- use args instead of static `entrypoints.sh`
- set properly `ClusterRole` & `Role`
- set list of namespace allow to watch( with glob pattern)

closes: #29