### PR TITLE
ci(release-please): fix issues trig wf on tags

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,6 +12,7 @@
   ],
   "separate-pull-requests": true,
   "sequential-calls": true,
+  "always-update": true,
   "packages": {
     "charts/crunchy-userinit": {
       "release-type": "helm",
@@ -29,16 +30,6 @@
         {
           "type": "chore",
           "section": "Chores"
-        }
-      ],
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "charts/_README.gotmpl"
-        },
-        {
-          "type": "generic",
-          "path": "charts/crunchy-userinit/README.md"
         }
       ]
     },

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -54,7 +54,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name == 'crunchy-userinit-controller')].version"
+          "jsonpath": "$.package[?(@.name.value == 'crunchy-userinit-controller')].version"
         }
       ]
     }

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -3,13 +3,7 @@ name: (Chart) Release
 on:
   push:
     tags:
-      - "chart*"
-  workflow_dispatch:
-  workflow_call:
-    inputs:
-      new-tag:
-        required: true
-        type: string
+      - chart-*
 jobs:
   release:
     permissions:

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "chart*"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      new-tag:
+        required: true
+        type: string
 jobs:
   release:
     permissions:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Debug
         run: |
           echo "${{ steps.vars.outputs.build-date }}"
+          echo "${{ stets.vars.outputs.git-hash }}"
 
       #platforms: linux/amd64,linux/arm64
       - name: Build and push
@@ -77,5 +78,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            BUILD_DATE=${{ steps.vars.outputs.build-date }}
             GIT_HASH=${{ steps.vars.outputs.git-hash }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,19 +54,16 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=pr
-            type=ref,event=branch
             type=edge,branch=main
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Debug
         run: |
           echo "${{ steps.vars.outputs.build-date }}"
-          echo "${{ stets.vars.outputs.git-hash }}"
+          echo "${{ steps.vars.outputs.git-hash }}"
 
       #platforms: linux/amd64,linux/arm64
-      - name: Build and push
+      - name: Build
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -78,5 +75,21 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILD_DATE=${{ steps.vars.outputs.build-date }}
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            GIT_HASH=${{ steps.vars.outputs.git-hash }}
+
+      - name: Build on PR
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          context: .
+          file: ./Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             GIT_HASH=${{ steps.vars.outputs.git-hash }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      new-tag:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -54,7 +59,7 @@ jobs:
           provenance: false
           build-args: |
             APP_VERSION=${{ github.ref_name }}
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            BUILD_DATE=${{ steps.vars.outputs.build-date }}
             GIT_HASH=${{ steps.vars.outputs.git-hash }}
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,18 +3,15 @@ name: (Docker) Release
 
 on:
   push:
-    tags:
-      - "v*"
-  workflow_dispatch:
-  workflow_call:
-    inputs:
-      new-tag:
-        required: true
-        type: string
+    tag:
+      - v*
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,7 +3,7 @@ name: (Docker) Release
 
 on:
   push:
-    tag:
+    tags:
       - v*
 
 jobs:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,7 +43,7 @@ jobs:
           mise run ci-test | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: MishaKav/pytest-coverage-comment@main
         with:
           junitxml-path: .coverage/junit.xml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,6 +43,7 @@ jobs:
           mise run ci-test | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
+        if: github.event_name != 'pull_request'
         uses: MishaKav/pytest-coverage-comment@main
         with:
           junitxml-path: .coverage/junit.xml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,3 +19,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+      - uses: ./github/workflows/chart-release.yml
+        if: ${{ steps.release.outputs.['charts/crunchy-userinit--release_created'] }}
+        with:
+          new-tag: ${{ steps.release.outputs.['charts/crunchy-userinit--tag_name'] }}
+      - uses: ./github/workflows/docker-release.yml
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          new-tag: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-
 permissions:
   issues: write
   contents: write
@@ -15,15 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        if: github.event_name != 'pull_request'
+        id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-      - uses: ./github/workflows/chart-release.yml
-        if: ${{ steps.release.outputs.['charts/crunchy-userinit--release_created'] }}
-        with:
-          new-tag: ${{ steps.release.outputs.['charts/crunchy-userinit--tag_name'] }}
-      - uses: ./github/workflows/docker-release.yml
-        if: ${{ steps.release.outputs.release_created }}
-        with:
-          new-tag: ${{ steps.release.outputs.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 WORKDIR /app
 
+ARG BUILD_DATE
+ARG GIT_HASH
+
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1
 

--- a/charts/_README.gotmpl
+++ b/charts/_README.gotmpl
@@ -1,11 +1,6 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-<!-- x-release-please-start-version -->
-![Version: 1.0.1
-](https://img.shields.io/static/v1?label=Version&message=1.0.1&color=informational) {{ template "chart.appVersionBadge" . }}
-<!-- x-release-please-end -->
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/crunchy-userinit/README.md
+++ b/charts/crunchy-userinit/README.md
@@ -1,10 +1,5 @@
 # crunchy-userinit-controller
 
-<!-- x-release-please-start-version -->
-![Version: 1.0.1
-](https://img.shields.io/static/v1?label=Version&message=1.0.1&color=informational) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
-<!-- x-release-please-end -->
-
 Installs crunchy-userinit-controller
 
 ## Maintainers


### PR DESCRIPTION
## Fix CI/CD Pipeline Issues


**Release Please Configuration:**
- Fixed uv.lock version update JSONPath expression (`@.name` → `@.name.value`)
- Simplified configuration by removing extra-files and enabling `always-update`
-  use own PAT instead of `GITHUB_TOKEN` to trig other workflows

**Docker Build & Release:**
- Added missing `ARG` declarations (`BUILD_DATE`, `GIT_HASH`) in Dockerfile
- Fixed typo in docker-build.yml (`stets` → `steps`)
- Improved build workflow to handle PRs differently (build without push)


**Chart Release:**
- Simplified chart-release trigger to only respond to `chart-*` tags
- Removed version badges from chart README (too complex to maintain with `release-please` actions)

**Testing & Coverage:**
- Fixed pytest coverage comments to only run on pull requests
- Improved workflow conditional logic


Close: #43
